### PR TITLE
fetchNodeByRating : Fixes table order in SQL FROM clause, fixes offset

### DIFF
--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobject.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobject.php
@@ -444,8 +444,8 @@ class ezsrRatingObject extends eZPersistentObject
                             FROM
                              ezcontentobject_tree,
                              ezcontentobject_tree owner_tree,
-                             ezcontentclass
-                             ,ezcontentobject
+                             ezcontentclass,
+                             ezcontentobject
                              $fromSql
                              $versionNameTables
                              $extendedAttributeFilter[tables]


### PR DESCRIPTION
The fetch function named "fetch_by_starrating" (calling ezsrRatingObject::fetchNodeByRating() ) can trigger a fatal error because of the SQL request.
Since "sqlPermissionChecking" and other "FROM" clauses use "INNER JOIN" statement,
and "ON" statement use "ezcontentobject" table, the declaration of ezcontentobject
have to be written before other clauses.

Further, the use of "offset" in eZDB::arrayQuery() method return array with
the same offset in keys, we can not have $row[0]
