### PR TITLE
Fix EZP-22095: eZ Star Rating does not work for anonymous

### DIFF
--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrserverfunctions.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrserverfunctions.php
@@ -58,7 +58,10 @@ class ezsrServerFunctions extends ezjscServerFunctions
 
         // Provide extra session protection on 4.1 (not possible on 4.0) by expecting user
         // to have an existing session (new session = mostlikely a spammer / hacker trying to manipulate rating)
-        if ( class_exists( 'eZSession' ) && eZSession::userHasSessionCookie() !== true )
+        if (
+            eZSession::userHasSessionCookie() !== true
+            && eZINI::instance()->variable( 'eZStarRating', 'AllowAnonymousRating' ) === 'disabled'
+        )
             return $ret;
 
         // Return if parameters are not valid attribute id + version numbers

--- a/packages/ezstarrating_extension/ezextension/ezstarrating/settings/site.ini.append.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/settings/site.ini.append.php
@@ -16,4 +16,18 @@ UseUserSession=enabled
 # Allows the user to change his rating after he has rated by returning to the page and rate again
 AllowChangeRating=enabled
 
+# Allow anonymous user to rate content.
+#  You also need :
+#    - to give access to anonymous users to starrating ezjscore functions
+#    - to enable the UseUserSession setting to avoid anonymous to be considered as a single individual
+#
+#  Activating this option (along with UseUserSession):
+#    - Will create a session for every anonymous user rating content.
+#    - might allow spamming since anonymous user is only authenticated by its session cookie.
+#
+#  Relation with the Session/ForceStart setting:
+#    If Session/ForceStart is set to enabled: Existing sessions will be used
+#    if Session/ForceStart is set to disabled: New sessions will be created for any user who starts rating content
+AllowAnonymousRating=disabled
+
 */ ?>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22095
## Description

Since we added an antispam feature in 4.1, using star rating for anonymous user was not working anymore. This patch reintroduce the anonymous rating by using a new setting that bypasses the spam feature (some user might be in a spam free environment such as some intranets). It also makes sure to create sessions only when needed.
## Tests

Manual tests
