### PR TITLE
 Compatibility with Legacy version 2017.10 and PHP 7

### DIFF
--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingdataobject.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingdataobject.php
@@ -33,11 +33,13 @@ class ezsrRatingDataObject extends eZPersistentObject
     protected $currentUserHasRated = null;
 
      /**
-     * Construct, use {@link ezsrRatingDataObject::create()} to create new objects.
+     * Construct, shouldn't be called directly
+     * Use {@link ezsrRatingDataObject::create()} to create new objects.
      *
+     * @access protected
      * @param array $row
      */
-    protected function __construct( $row )
+    public function __construct( $row )
     {
         $this->eZPersistentObject( $row );
     }

--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobject.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobject.php
@@ -26,11 +26,13 @@
 class ezsrRatingObject extends eZPersistentObject
 {
      /**
-     * Construct, use {@link ezsrRatingObject::create()} to create new objects.
+     * Construct, shouldn't be called directly
+     * Use {@link ezsrRatingObject::create()} to create new objects.
      *
+     * @access protected
      * @param array $row
      */
-    protected function __construct( $row )
+    public function __construct( $row )
     {
         $this->eZPersistentObject( $row );
     }

--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobjecttreenode.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobjecttreenode.php
@@ -43,7 +43,7 @@ class ezsrRatingObjectTreeNode extends eZContentObjectTreeNode
      */
     public function __construct( $row )
     {
-        $this->eZContentObjectTreeNode( $row );
+        $this->eZPersistentObject( $row );
     }
 
     /** definition of ezsrRatingObjectTreeNode, extends eZContentObjectTreeNode definition

--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobjecttreenode.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingobjecttreenode.php
@@ -35,11 +35,13 @@
 class ezsrRatingObjectTreeNode extends eZContentObjectTreeNode
 {
      /**
-     * Construct
+     * Construct, shouldn't be called directly
+     * Use {@link ezsrRatingObjectTreeNode::makeObjectsArray()} to create new objects.
      * 
+     * @access protected
      * @param array $row
      */
-    protected function __construct( $row )
+    public function __construct( $row )
     {
         $this->eZContentObjectTreeNode( $row );
     }


### PR DESCRIPTION
With the changes introduced in https://github.com/ezsystems/ezpublish-legacy/pull/1233 eZPersistentObject now has "__construct" method with public visibility. Classes that are extending eZPersistentObject should also have "__construct" method with public visibility (instead of protected) as limiting visibility in subclasses is not permitted in PHP and results in fatal error.