### PR TITLE
Fix EZP-29591: deprecated PHP4 style class constructor

### DIFF
--- a/packages/ezstarrating_extension/ezextension/ezstarrating/autoloads/ezsrtemplateoperators.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/autoloads/ezsrtemplateoperators.php
@@ -25,10 +25,6 @@
 
 class ezsrTemplateOperators
 {
-    function ezsrTemplateOperators()
-    {
-    }
-
     function operatorList()
     {
         return array( 'fetch_starrating_data',

--- a/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingfilter.php
+++ b/packages/ezstarrating_extension/ezextension/ezstarrating/classes/ezsrratingfilter.php
@@ -30,10 +30,6 @@
 
 class ezsrRatingFilter
 {
-    function ezsrRatingFilter()
-    {
-    }
-
     function createSqlParts( $params )
     {
         /*


### PR DESCRIPTION
Use of deprecated PHP4 style class constructor is not supported since PHP 7.